### PR TITLE
improved per-session iterm tab color support

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 source "$SHA1N_PROFILE_HOME/scripts/lib.zsh"
-
+source "$SHA1N_PROFILE_HOME/include/iterm/functions"
 
 function toupper() {
   echo "$1" | tr a-z A-Z
@@ -11,30 +11,6 @@ function tolower() {
   echo "$1" | tr A-Z a-z
 }
 
-#
-# iTerm only
-#
-function set_tab_color() {
-    case $1 in
-    green)
-    echo -n "\033]6;1;bg;red;brightness;57\a"
-    echo -n "\033]6;1;bg;green;brightness;197\a"
-    echo -n "\033]6;1;bg;blue;brightness;77\a"
-    ;;
-    red)
-    echo -n "\033]6;1;bg;red;brightness;270\a"
-    echo -n "\033]6;1;bg;green;brightness;60\a"
-    echo -n "\033]6;1;bg;blue;brightness;83\a"
-    ;;
-    orange)
-    echo -n "\033]6;1;bg;red;brightness;227\a"
-    echo -n "\033]6;1;bg;green;brightness;143\a"
-    echo -n "\033]6;1;bg;blue;brightness;10\a"
-    ;;
-    *)
-    echo -n "\033]6;1;bg;*;default\a"
-    esac
- }
 
 #
 # Adds the provided alias to the last command

--- a/include/iterm/functions
+++ b/include/iterm/functions
@@ -1,0 +1,64 @@
+#!/usr/bin/env zsh
+
+[ ! -n "$ITERM_PROFILE" ] && exit
+
+local colors=(green yellow orange red white grey)
+
+#
+# iTerm only utilities
+#
+
+function set_tab_color_rgb() {
+  echo -n "\033]6;1;bg;red;brightness;$1\a"
+  echo -n "\033]6;1;bg;green;brightness;$2\a"
+  echo -n "\033]6;1;bg;blue;brightness;$3\a"
+}
+
+function reset_tab_color() {
+  unset __SHA1N_PROFILE_TABCOLOR
+  echo -n "\033]6;1;bg;*;default\a"
+}
+
+function set_tab_color() {
+  local color=$(echo "${1}" | xargs)
+  # local colors=(green yellow orange red white grey)
+
+  case $color in
+  green)
+    set_tab_color_rgb 57 180 77
+    ;;
+
+  yellow)
+    set_tab_color_rgb 197 197 0
+    ;;
+
+  red)
+    set_tab_color_rgb 190 60 83
+    ;;
+
+  orange)
+    set_tab_color_rgb 227 143 10
+    ;;
+
+  white)
+    set_tab_color_rgb 180 180 180
+    ;;
+
+  grey)
+    set_tab_color_rgb 90 90 90
+    ;;
+
+  default)
+    reset_tab_color
+    ;;
+
+  *)
+    if (($colors[(Ie)$__SHA1N_PROFILE_TABCOLOR])); then
+      set_tab_color "$__SHA1N_PROFILE_TABCOLOR"
+    else
+      color=default
+    fi
+  esac
+
+  export __SHA1N_PROFILE_TABCOLOR="$color"
+ }


### PR DESCRIPTION
Tab colors are now stored in an environment variable which makes them sticky per session.
Whenever `set_tab_color` is called without arguments, that env-var is evaluated and any set color is restored. This function can be called in prompt decoration hooks to restore color automatically.

Example of setting tab color based on an env-var in iTerm `prompt_context`:
```
prompt_context() {  
  if [[ "$ENV_CONTEXT" = "development" ]]; then
    set_tab_color green
  elif [[ "$ENV_CONTEXT" = "staging" ]]; then
    set_tab_color orange
  elif [[ "$ENV_CONTEXT" = "production" ]]; then
    set_tab_color red
  else
    set_tab_color
  fi
}
```