### PR TITLE
feat: add wt and wt_rm git worktree helpers

### DIFF
--- a/dotfiles/.gitignore_global
+++ b/dotfiles/.gitignore_global
@@ -44,12 +44,6 @@ vendor/
 .vagrant
 .vm_config.json
 
-# My conventions
-.pethrc
-.bertconfig
-.start
-.test-env
-
 # Claude code
 .claude/settings.local.json
 .claude/worktrees/
@@ -57,15 +51,22 @@ vendor/
 # Gemini CLI
 .gemini
 
-# Conversational LLM agent reviews directory
-.reviews
-.plans
-
 # Other dirty files
 *.log
 *.jfr
 
-.benchmarks/
-
 # Zsh bytecode compiled files
 *.zwc
+
+#
+# My conventions
+#
+.pethrc
+.bertconfig
+.start
+.test-env
+# Conversational LLM agent reviews directory
+.reviews/
+.plans/
+.benchmarks/
+.worktree/

--- a/include/functions
+++ b/include/functions
@@ -221,3 +221,120 @@ function export_openjdk_formula() {
   echo "💡 You can also add \$JAVA_HOME/bin to your PATH:"
   echo "   export PATH=\"\$JAVA_HOME/bin:\$PATH\""
 }
+
+# Git worktree management
+
+function __profile_git_repo_root() {
+  local git_common_dir
+  git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+  if [[ $? -ne 0 ]]; then
+    __profile_log_error "not inside a git repository"
+    return 1
+  fi
+  # Resolve to absolute path (relative when in main worktree, absolute in secondary)
+  # then take the parent of .git to get the repo root.
+  echo "${git_common_dir:A:h}"
+}
+
+function wt() {
+  local branch="$1"
+
+  if [[ -z "$branch" ]]; then
+    echo "Usage: wt <branch-name>"
+    git worktree list 2>/dev/null
+    return 1
+  fi
+
+  local root
+  root=$(__profile_git_repo_root) || return 1
+
+  local wt_dir="$root/.worktree/$branch"
+
+  if [[ -d "$wt_dir" ]]; then
+    __profile_log_info "worktree already exists, entering '$wt_dir'"
+    cd "$wt_dir"
+    return 0
+  fi
+
+  local output
+  if git show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then
+    output=$(git worktree add "$wt_dir" "$branch" 2>&1)
+  else
+    output=$(git worktree add -b "$branch" "$wt_dir" 2>&1)
+  fi
+
+  if [[ $? -ne 0 ]]; then
+    __profile_log_error "failed to create worktree: $output"
+    return 1
+  fi
+
+  cd "$wt_dir"
+  __profile_log_success "worktree created at '.worktree/$branch'"
+}
+
+function wt_rm() {
+  local branch="$1"
+
+  if [[ -z "$branch" ]]; then
+    echo "Usage: wt_rm <branch-name>"
+    git worktree list 2>/dev/null
+    return 1
+  fi
+
+  local root
+  root=$(__profile_git_repo_root) || return 1
+
+  local wt_dir="$root/.worktree/$branch"
+
+  if [[ ! -d "$wt_dir" ]]; then
+    __profile_log_error "worktree not found: '.worktree/$branch'"
+    return 1
+  fi
+
+  echo "  Worktree: .worktree/$branch"
+  echo "  Branch:   $branch"
+  echo ""
+
+  local reply
+  read "reply?Remove worktree '.worktree/$branch'? [y/N] "
+  if [[ "$reply" != [yY] ]]; then
+    __profile_log_info "cancelled"
+    return 0
+  fi
+
+  # if cwd is inside the worktree, move out first
+  if [[ "$PWD" == "$wt_dir"* ]]; then
+    cd "$root"
+  fi
+
+  local output
+  output=$(git worktree remove "$wt_dir" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    __profile_log_error "failed to remove worktree: $output"
+    __profile_log_warn "try cleaning up manually or use: git worktree remove --force '$wt_dir'"
+    return 1
+  fi
+
+  __profile_log_success "worktree removed"
+
+  read "reply?Also delete local branch '$branch'? [y/N] "
+  if [[ "$reply" != [yY] ]]; then
+    __profile_log_info "keeping branch '$branch'"
+    return 0
+  fi
+
+  output=$(git branch -d "$branch" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    __profile_log_warn "branch not fully merged: $output"
+    read "reply?Force delete branch '$branch'? [y/N] "
+    if [[ "$reply" == [yY] ]]; then
+      git branch -D "$branch"
+      __profile_log_success "branch '$branch' force deleted"
+    else
+      __profile_log_info "keeping branch '$branch'"
+    fi
+    return 0
+  fi
+
+  __profile_log_success "branch '$branch' deleted"
+}

--- a/tests/worktree.test.sh
+++ b/tests/worktree.test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env zsh
+
+source "$__ZSH_SCRIPTEST_HOME/matchers.sh"
+source "$__ZSH_SCRIPTEST_HOME/test_util.sh"
+fingerprint=$(cat /dev/urandom | base64 | tr -dc '0-9a-zA-Z' | head -c50)
+
+setup() {
+  if [[ "$(ls -A $HOME)" ]]; then
+    echo "the test \$HOME directory is expected to be a temporary empty directory"
+    exit 1
+  else
+    test_setup_title
+    touch "$HOME/$fingerprint"
+    source "$SHA1N_PROFILE_TESTS_HOME/../install.sh"
+    source "$SHA1N_PROFILE_TESTS_HOME/../load.zsh"
+  fi
+}
+
+cleanup() {
+  test_teardown_title
+  assert_file_exists "$HOME/$fingerprint"
+  if [[ -f "$HOME/$fingerprint" ]]; then
+    echo
+    rm -rf "$HOME"
+    mkdir -p "$HOME"
+  fi
+}
+
+create_test_repo() {
+  local repo_dir="$HOME/test-repo"
+  mkdir -p "$repo_dir"
+  cd "$repo_dir"
+  git init -q
+  git commit -q --allow-empty -m "initial commit"
+}
+
+# ------ wt tests ------
+
+function test_wt_no_args() {
+  test_case_title
+  create_test_repo
+
+  local output
+  output=$(wt 2>&1)
+  assert_exit_code 1 "wt"
+  assert_contains "$output" "Usage: wt"
+}
+
+function test_wt_new_branch() {
+  test_case_title
+  create_test_repo
+
+  wt test-branch >/dev/null 2>&1
+  local repo_dir="$HOME/test-repo"
+
+  assert_dir_exists "$repo_dir/.worktree/test-branch"
+  assert_contains "$PWD" ".worktree/test-branch"
+
+  # verify branch was created
+  cd "$repo_dir"
+  local branches
+  branches=$(git branch --list test-branch)
+  assert_not_empty "$branches"
+}
+
+function test_wt_existing_branch() {
+  test_case_title
+  create_test_repo
+
+  # create branch first without a worktree
+  git branch existing-branch
+
+  wt existing-branch >/dev/null 2>&1
+  local repo_dir="$HOME/test-repo"
+
+  assert_dir_exists "$repo_dir/.worktree/existing-branch"
+  assert_contains "$PWD" ".worktree/existing-branch"
+}
+
+function test_wt_reenter_existing() {
+  test_case_title
+  create_test_repo
+
+  local repo_dir="$HOME/test-repo"
+
+  wt reenter-branch >/dev/null 2>&1
+  assert_dir_exists "$repo_dir/.worktree/reenter-branch"
+
+  # go back to repo root, then re-enter
+  cd "$repo_dir"
+  wt reenter-branch >/dev/null 2>&1
+  assert_contains "$PWD" ".worktree/reenter-branch"
+}
+
+function test_wt_not_git_repo() {
+  test_case_title
+
+  local non_repo="$HOME/not-a-repo"
+  mkdir -p "$non_repo"
+  cd "$non_repo"
+
+  assert_exit_code 1 "wt some-branch"
+}
+
+function test_wt_slash_branch() {
+  test_case_title
+  create_test_repo
+
+  local repo_dir="$HOME/test-repo"
+
+  wt feature/foo >/dev/null 2>&1
+
+  assert_dir_exists "$repo_dir/.worktree/feature/foo"
+  assert_contains "$PWD" ".worktree/feature/foo"
+}
+
+# ------ wt_rm tests ------
+
+function test_wt_rm_no_args() {
+  test_case_title
+  create_test_repo
+
+  local output
+  output=$(wt_rm 2>&1)
+  assert_exit_code 1 "wt_rm"
+  assert_contains "$output" "Usage: wt_rm"
+}
+
+function test_wt_rm_nonexistent() {
+  test_case_title
+  create_test_repo
+
+  assert_exit_code 1 "wt_rm no-such-branch"
+}
+
+function test_wt_rm_removes_worktree() {
+  test_case_title
+  create_test_repo
+
+  local repo_dir="$HOME/test-repo"
+
+  wt rm-wt-branch >/dev/null 2>&1
+  cd "$repo_dir"
+
+  assert_dir_exists "$repo_dir/.worktree/rm-wt-branch"
+
+  # answer y to remove worktree, n to keep branch
+  echo "y\nn" | wt_rm rm-wt-branch >/dev/null 2>&1
+
+  assert_dir_not_exists "$repo_dir/.worktree/rm-wt-branch"
+
+  # branch should still exist
+  local branches
+  branches=$(git branch --list rm-wt-branch)
+  assert_not_empty "$branches"
+}
+
+function test_wt_rm_removes_branch() {
+  test_case_title
+  create_test_repo
+
+  local repo_dir="$HOME/test-repo"
+
+  wt rm-both-branch >/dev/null 2>&1
+  cd "$repo_dir"
+
+  # answer y to both prompts (remove worktree + delete branch)
+  echo "y\ny" | wt_rm rm-both-branch >/dev/null 2>&1
+
+  assert_dir_not_exists "$repo_dir/.worktree/rm-both-branch"
+
+  # branch should be gone
+  local branches
+  branches=$(git branch --list rm-both-branch)
+  assert_empty "$branches"
+}
+
+function test_wt_rm_from_inside_worktree() {
+  test_case_title
+  create_test_repo
+
+  local repo_dir="$HOME/test-repo"
+
+  # create the worktree and manually cd into it
+  wt inside-branch >/dev/null 2>&1
+  cd "$repo_dir/.worktree/inside-branch"
+
+  # remove while cwd is inside the worktree — function should cd out first
+  echo "y\nn" | wt_rm inside-branch >/dev/null 2>&1
+
+  assert_dir_not_exists "$repo_dir/.worktree/inside-branch"
+}
+
+function test_wt_rm_decline() {
+  test_case_title
+  create_test_repo
+
+  local repo_dir="$HOME/test-repo"
+
+  wt decline-branch >/dev/null 2>&1
+  cd "$repo_dir"
+
+  # answer n to first prompt — nothing should be removed
+  echo "n" | wt_rm decline-branch >/dev/null 2>&1
+
+  assert_dir_exists "$repo_dir/.worktree/decline-branch"
+}
+
+setup
+run_test test_wt_no_args
+run_test test_wt_new_branch
+run_test test_wt_existing_branch
+run_test test_wt_reenter_existing
+run_test test_wt_not_git_repo
+run_test test_wt_slash_branch
+run_test test_wt_rm_no_args
+run_test test_wt_rm_nonexistent
+run_test test_wt_rm_removes_worktree
+run_test test_wt_rm_removes_branch
+run_test test_wt_rm_from_inside_worktree
+run_test test_wt_rm_decline
+finish_tests
+cleanup


### PR DESCRIPTION
## Summary
- Add `wt <branch>` — creates a worktree under `.worktree/`, handles new/existing branches, cd's into it
- Add `wt_rm <branch>` — interactive worktree removal with prompts for worktree and branch deletion
- Reorganize `.gitignore_global` with consolidated "My conventions" section, add `.worktree/` pattern
- Add 12 test cases covering edge cases (slash branches, re-entry, removal from inside worktree, etc.)
- Update `zsh-scriptest` submodule to include TAP test file name headers

## Test plan
- [x] `make test` passes — all 17 tests (12 worktree + 5 sanity)
- [x] Manual smoke test: `wt test-branch`, `wt test-branch` (re-enter), `wt_rm test-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)