### PR TITLE
fix(tests): make worktree/sanity tests pass on ubuntu CI

### DIFF
--- a/tests/sanity.test.sh
+++ b/tests/sanity.test.sh
@@ -24,6 +24,7 @@ cleanup() {
   if [[ -f "$HOME/$fingerprint" ]]; then
     echo
     rm -rf "$HOME"
+    mkdir -p "$HOME"
   fi
 }
 

--- a/tests/worktree.test.sh
+++ b/tests/worktree.test.sh
@@ -31,6 +31,8 @@ create_test_repo() {
   mkdir -p "$repo_dir"
   cd "$repo_dir"
   git init -q
+  git config user.email "test@example.com"
+  git config user.name "Test"
   git commit -q --allow-empty -m "initial commit"
 }
 


### PR DESCRIPTION
## Problem

CI failed on `master` (run [26995644123](https://github.com/sha1n/profile/actions/runs/26995644123)). **ubuntu-latest** failed; **macos-latest** passed. The failure was not caused by any code change — it was surfaced by a GitHub runner image change plus an order-dependent test ordering on ubuntu.

Two independent, pre-existing test bugs:

### 1. Missing git identity in worktree sandbox repo
`create_test_repo()` ran `git init` + `git commit` in a sandboxed empty `$HOME` (no `~/.gitconfig`) without configuring an identity, relying on the runner's ambient git config. The current ubuntu image no longer provides one, so the commit aborted with `fatal: empty ident name not allowed` (tests `test_wt_new_branch`, `test_wt_rm_removes_worktree`).

**Fix:** set an explicit local git identity in the sandbox repo.

### 2. sanity cleanup deletes $HOME without recreating it
The runner sets the sandbox `$HOME` once and relies on each test file's cleanup to leave it existing for the next file. sanity's cleanup did `rm -rf $HOME` *without* `mkdir -p $HOME` (unlike worktree's cleanup). `find` orders sanity before worktree on ubuntu, so by the time worktree's setup ran `touch $HOME/$fingerprint`, `$HOME` no longer existed — the touch silently failed and the teardown's `assert_file_exists` then failed, making the file exit non-zero even though all 17 assertions passed.

This was masked on master because the failing worktree tests made `finish_tests` exit before cleanup ran. Fixing bug #1 exposed bug #2.

**Fix:** add `mkdir -p $HOME` to sanity's cleanup, matching worktree's convention.

## Verification

`make test` passes locally, and I reproduced the ubuntu `find` order (sanity → worktree) locally — both files now exit 0. CI on this PR confirms ubuntu-latest + macos-latest.