### PR TITLE
feat: add fzf-tab plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "zsh-plugins/zsh-defer"]
 	path = zsh-plugins/zsh-defer
 	url = https://github.com/romkatv/zsh-defer.git
+[submodule "zsh-plugins/fzf-tab"]
+	path = zsh-plugins/fzf-tab
+	url = https://github.com/Aloxaf/fzf-tab

--- a/include/completions
+++ b/include/completions
@@ -13,3 +13,6 @@ else
   compinit -C
 fi
 autoload -U +X bashcompinit && bashcompinit
+
+zstyle ':fzf-tab:*' switch-group ',' '.'
+zstyle ':fzf-tab:complete:cd:*' fzf-preview 'ls -1 --color=always $realpath'

--- a/load.zsh
+++ b/load.zsh
@@ -34,6 +34,13 @@ source $SHA1N_PROFILE_HOME/include/completions
 source $SHA1N_PROFILE_HOME/include/history
 source $SHA1N_PROFILE_HOME/include/prompt
 
+# fzf-tab: after compinit (include/completions), before zsh-syntax-highlighting
+if [[ -o interactive ]]; then
+  zsh-defer source $SHA1N_PROFILE_HOME/zsh-plugins/fzf-tab/fzf-tab.plugin.zsh
+else
+  source $SHA1N_PROFILE_HOME/zsh-plugins/fzf-tab/fzf-tab.plugin.zsh
+fi
+
 # deferred keybindings that depend on history-substring-search
 if [[ -o interactive ]]; then
   zsh-defer bindkey "^[[A" history-substring-search-up


### PR DESCRIPTION
## Summary

- Adds [fzf-tab](https://github.com/Aloxaf/fzf-tab) as a git submodule under `zsh-plugins/fzf-tab`
- Wires it into `load.zsh` using the same `zsh-defer`/non-interactive pattern as all other plugins — deferred in interactive sessions, sourced synchronously otherwise (for tests)
- Loaded after `include/completions` (which calls `compinit`) and before `zsh-syntax-highlighting` (hard ordering requirements for the plugin)
- Adds two `zstyle` options to `include/completions`: `switch-group` (`,`/`.` to jump between completion groups) and a `cd` directory preview via `ls`

## Prerequisites

`fzf` must be installed on the machine (`brew install fzf` on macOS). It is not managed by this repo.