### PR TITLE
feat(install): manage global Claude Code instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Personal Zsh configuration repository: shell environment, dotfiles, aliases, fun
 - **`scripts/`** — Executable tools, added to `$PATH` via `include/exports`. Any file here is a CLI command.
   - `lib.zsh` — Shared library (logging, tree search) sourced by functions and install script
 - **`dotfiles/`** — Symlinked to `$HOME` during install (not copied — changes are live)
+- **`claude/`** — Global Claude Code instructions (`CLAUDE.md`). `install.sh` symlinks `~/.claude/CLAUDE.md` to this file. If `~/.claude/CLAUDE.md` already exists, install prompts `[n/Y]` before replacing it (default Yes); an existing correct link is left untouched
 - **`zsh-plugins/`, `zsh-theme/`** — Git submodules
 - **`tests/`** — Test suite using `zsh-scriptest` submodule
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,8 @@
+## Commits
+- Omit `Co-Authored-By: Claude ...` trailers on all new commits. Preserve only if already present when rebasing.
+
+## Session Specs & Plans
+- Never `git add` or commit session specs or plans, unless the project has explicit rules allowing it or the user explicitly requests it.
+
+## Development Workflow
+- RED/GREEN/REFACTOR TDD cycle — bug fixes and features always start with failing tests that cover all specs. Production code is written against failing tests.

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ source "$SHA1N_PROFILE_HOME/scripts/lib.zsh"
 source "$SHA1N_PROFILE_HOME/include/exports"
 
 dotzshrc="$HOME/.zshrc"
+dotclauderc="$HOME/.claude/CLAUDE.md"
 dotfiles_dir="$SHA1N_PROFILE_HOME/dotfiles"
 dirs=("$HOME/.local/bin" "$CODE/w")
 
@@ -30,6 +31,34 @@ function install_source_command() {
     __profile_log_info "installed successfully!"
     __profile_log_info "to verify installation start new session or source $dotzshrc"
   fi
+}
+
+function install_claude_global() {
+  __profile_log_info "linking global Claude Code instructions..."
+  local claude_md="$SHA1N_PROFILE_HOME/claude/CLAUDE.md"
+
+  create_directory "${dotclauderc:h}"
+
+  # Already linked to the profile — nothing to do.
+  if [[ -L "$dotclauderc" && "$(readlink "$dotclauderc")" == "$claude_md" ]]; then
+    __profile_log_warn "'$dotclauderc' is already linked to the profile. Skipping..."
+    return 0
+  fi
+
+  # Existing file or link: replacing it is destructive, so ask first (default: Yes).
+  if [[ -e "$dotclauderc" || -L "$dotclauderc" ]]; then
+    local reply
+    read "reply?'$dotclauderc' already exists. Replace it with a link to the profile's CLAUDE.md? [n/Y] "
+    if [[ "$reply" == [nN] ]]; then
+      __profile_log_info "keeping existing '$dotclauderc'"
+      return 0
+    fi
+    rm -f "$dotclauderc"
+  fi
+
+  __profile_log_info "linking CLAUDE.md..."
+  ln -s "$claude_md" "$dotclauderc"
+  return "$?"
 }
 
 function link_dotfile() {
@@ -99,7 +128,9 @@ link_dotfiles
 
 create_directories 
 
-validate_shell_rc_file && install_source_command 
+validate_shell_rc_file && install_source_command
+
+install_claude_global
 
 setup_neovim
 

--- a/tests/sanity.test.sh
+++ b/tests/sanity.test.sh
@@ -62,11 +62,69 @@ function test_dir_path_elements() {
   assert_contains "$PATH" "$SHA1N_PROFILE_HOME/scripts"
 }
 
+function test_claude_global_linked() {
+  test_case_title
+
+  # fresh install (empty sandbox HOME) symlinks ~/.claude/CLAUDE.md to the profile
+  assert_equal "$(readlink "$HOME/.claude/CLAUDE.md")" "$SHA1N_PROFILE_HOME/claude/CLAUDE.md"
+}
+
+function test_claude_global_idempotent() {
+  test_case_title
+
+  # re-running against an already-correct link is a silent no-op (no prompt, no error)
+  install_claude_global >/dev/null 2>&1
+  assert_equal "$?" "0"
+  assert_equal "$(readlink "$HOME/.claude/CLAUDE.md")" "$SHA1N_PROFILE_HOME/claude/CLAUDE.md"
+}
+
+function test_claude_global_keep_existing() {
+  test_case_title
+
+  # existing file + 'n' answer -> keep the user's own file untouched
+  rm -f "$HOME/.claude/CLAUDE.md"
+  print "KEEP MY OWN RULES" >"$HOME/.claude/CLAUDE.md"
+
+  print "n" | install_claude_global >/dev/null 2>&1
+
+  assert_empty "$(readlink "$HOME/.claude/CLAUDE.md" 2>/dev/null)"
+  assert_contains "$(cat "$HOME/.claude/CLAUDE.md")" "KEEP MY OWN RULES"
+}
+
+function test_claude_global_replace_existing() {
+  test_case_title
+
+  # existing file + 'Y' answer -> delete it and link to the profile
+  rm -f "$HOME/.claude/CLAUDE.md"
+  print "OLD CONTENT" >"$HOME/.claude/CLAUDE.md"
+
+  print "Y" | install_claude_global >/dev/null 2>&1
+
+  assert_equal "$(readlink "$HOME/.claude/CLAUDE.md")" "$SHA1N_PROFILE_HOME/claude/CLAUDE.md"
+}
+
+function test_claude_global_default_replaces() {
+  test_case_title
+
+  # existing file + empty answer (Enter) -> default is Yes, so replace
+  rm -f "$HOME/.claude/CLAUDE.md"
+  print "OLD CONTENT" >"$HOME/.claude/CLAUDE.md"
+
+  print "" | install_claude_global >/dev/null 2>&1
+
+  assert_equal "$(readlink "$HOME/.claude/CLAUDE.md")" "$SHA1N_PROFILE_HOME/claude/CLAUDE.md"
+}
+
 install_profile
 run_test test_source
 run_test test_locale_set
 run_test test_env_vars
 run_test test_dir_layout
 run_test test_dir_path_elements
+run_test test_claude_global_linked
+run_test test_claude_global_idempotent
+run_test test_claude_global_keep_existing
+run_test test_claude_global_replace_existing
+run_test test_claude_global_default_replaces
 finish_tests
 cleanup


### PR DESCRIPTION
## Summary
Version-controls the global Claude Code instructions and wires them into the install flow.

- **`claude/CLAUDE.md`** (new) — the global Claude Code instructions, now tracked in the repo.
- **`install.sh`** — new `install_claude_global()` symlinks `~/.claude/CLAUDE.md` → `claude/CLAUDE.md`, called from the main install flow.
  - If `~/.claude/CLAUDE.md` already exists, it prompts `[n/Y]` before replacing it (default **Yes**: deletes the existing file and links; **No** keeps the user's file untouched).
  - An existing correct symlink is left untouched (idempotent, no prompt).
- **`CLAUDE.md`** — documents the new `claude/` directory and install behavior.

## Behavior notes
- `update_profile` (git pull + submodule update) does **not** touch `~/.claude/CLAUDE.md`; wiring happens only when `./install.sh` is run.

## Tests
Added sanity tests covering every branch (TDD, RED first):
- `test_claude_global_linked` — fresh install creates the symlink
- `test_claude_global_idempotent` — re-run against a correct link is a silent no-op
- `test_claude_global_keep_existing` — existing file + `n` keeps it untouched
- `test_claude_global_replace_existing` — existing file + `Y` replaces with the link
- `test_claude_global_default_replaces` — existing file + Enter defaults to replace

All 22 tests pass locally (`make test`).